### PR TITLE
fix when delivery attempt is nil

### DIFF
--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -102,6 +102,10 @@ func (b *Backend) Receive(ctx context.Context, numMessages uint32, visibilityTim
 		}
 		group.Go(func() error {
 			recvErr := pubsubSubscription.Receive(gctx, func(ctx context.Context, message *pubsub.Message) {
+				deliveryAttemptDefault := -1
+				if message.DeliveryAttempt == nil {
+					message.DeliveryAttempt = &deliveryAttemptDefault
+				}
 				metadata := Metadata{
 					pubsubMessage:   message,
 					PublishTime:     message.PublishTime,

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -102,6 +102,7 @@ func (b *Backend) Receive(ctx context.Context, numMessages uint32, visibilityTim
 		}
 		group.Go(func() error {
 			recvErr := pubsubSubscription.Receive(gctx, func(ctx context.Context, message *pubsub.Message) {
+				// deliveryAttempt is nil for subscriptions without a dlq
 				deliveryAttemptDefault := -1
 				if message.DeliveryAttempt == nil {
 					message.DeliveryAttempt = &deliveryAttemptDefault

--- a/gcp/gcp_test.go
+++ b/gcp/gcp_test.go
@@ -149,10 +149,7 @@ func (s *BackendTestSuite) TestReceiveNoDLQSetup() {
 		// dlq sub does not have a dlq policy so Delivery attempt should be nil
 		Subscriptions:      []string{"dlq"},
 	}
-	getLogger := func(_ context.Context) hedwig.Logger {
-		return logger
-	}
-	backend := gcp.NewBackend(settings, getLogger)
+	backend := gcp.NewBackend(settings, logger)
 
 	payload := []byte(`{"vehicle_id": "C_123"}`)
 	attributes := map[string]string{
@@ -180,8 +177,7 @@ func (s *BackendTestSuite) TestReceiveNoDLQSetup() {
 		Once()
 
 	testutils.RunAndWait(func() {
-		err := backend.Receive(ctx, numMessages, visibilityTimeout, s.messageCh)
-		s.True(err.Error() == "draining" || err == context.Canceled)
+		err = backend.Receive(ctx, numMessages, visibilityTimeout, s.messageCh)
 		close(s.messageCh)
 	})
 	wg.Wait()

--- a/gcp/gcp_test.go
+++ b/gcp/gcp_test.go
@@ -136,6 +136,62 @@ func (s *BackendTestSuite) TestReceive() {
 	}
 }
 
+func (s *BackendTestSuite) TestReceiveNoDLQSetup() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+	defer cancel()
+	numMessages := uint32(10)
+	visibilityTimeout := time.Second * 10
+	logger := &fakeLogger{}
+
+	settings := gcp.Settings{
+		GoogleCloudProject: "emulator-project",
+		QueueName:          "dev-myapp",
+		// dlq sub does not have a dlq policy so Delivery attempt should be nil
+		Subscriptions:      []string{"dlq"},
+	}
+	getLogger := func(_ context.Context) hedwig.Logger {
+		return logger
+	}
+	backend := gcp.NewBackend(settings, getLogger)
+
+	payload := []byte(`{"vehicle_id": "C_123"}`)
+	attributes := map[string]string{
+		"foo": "bar",
+	}
+	err := s.publish(payload, attributes, "hedwig-dev-myapp-dlq", "")
+	s.Require().NoError(err)
+
+	m := mock.Mock{}
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for receivedMessage := range s.messageCh {
+			m.MethodCalled("MessageReceived", receivedMessage.Payload, receivedMessage.Attributes, receivedMessage.ProviderMetadata)
+		}
+	}()
+	m.On("MessageReceived", payload, attributes, mock.AnythingOfType("gcp.Metadata")).
+		// message must be acked or Receive never returns
+		Run(func(args mock.Arguments) {
+			err := backend.AckMessage(ctx, args.Get(2))
+			s.Require().NoError(err)
+		}).
+		Return().
+		Once()
+
+	testutils.RunAndWait(func() {
+		err := backend.Receive(ctx, numMessages, visibilityTimeout, s.messageCh)
+		s.True(err.Error() == "draining" || err == context.Canceled)
+		close(s.messageCh)
+	})
+	wg.Wait()
+
+	if m.AssertExpectations(s.T()) {
+		providerMetadata := m.Calls[0].Arguments.Get(2).(gcp.Metadata)
+		s.Equal(-1, providerMetadata.DeliveryAttempt)
+	}
+}
+
 func (s *BackendTestSuite) TestReceiveCrossProject() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
 	defer cancel()

--- a/gcp/gcp_test.go
+++ b/gcp/gcp_test.go
@@ -147,7 +147,7 @@ func (s *BackendTestSuite) TestReceiveNoDLQSetup() {
 		GoogleCloudProject: "emulator-project",
 		QueueName:          "dev-myapp",
 		// dlq sub does not have a dlq policy so Delivery attempt should be nil
-		Subscriptions:      []string{"dlq"},
+		Subscriptions: []string{"dlq"},
 	}
 	backend := gcp.NewBackend(settings, logger)
 


### PR DESCRIPTION
Delivery Attempt is nil when the DLQ is not in use for a subscription